### PR TITLE
feat: Remember Me 로그인 기능 추가

### DIFF
--- a/admin-api/src/main/java/me/synology/hajubal/coins/admin/config/JwtProperties.java
+++ b/admin-api/src/main/java/me/synology/hajubal/coins/admin/config/JwtProperties.java
@@ -24,4 +24,7 @@ public class JwtProperties {
 
   /** Refresh Token 유효기간 (밀리초) */
   private Long refreshTokenValidity;
+
+  /** Remember Me Token 유효기간 (밀리초, 15일) */
+  private Long rememberMeTokenValidity;
 }

--- a/admin-api/src/main/java/me/synology/hajubal/coins/admin/controller/AuthController.java
+++ b/admin-api/src/main/java/me/synology/hajubal/coins/admin/controller/AuthController.java
@@ -50,7 +50,8 @@ public class AuthController {
 
       // JWT 토큰 생성
       String accessToken = jwtTokenProvider.createAccessToken(authentication);
-      String refreshToken = jwtTokenProvider.createRefreshToken(loginRequest.getLoginId());
+      String refreshToken = jwtTokenProvider.createRefreshToken(
+          loginRequest.getLoginId(), loginRequest.isRememberMe());
 
       // UserDetails에서 사용자 정보 추출
       UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/admin-api/src/main/java/me/synology/hajubal/coins/admin/dto/LoginRequest.java
+++ b/admin-api/src/main/java/me/synology/hajubal/coins/admin/dto/LoginRequest.java
@@ -22,4 +22,7 @@ public class LoginRequest {
   /** 비밀번호 */
   @NotBlank(message = "비밀번호는 필수입니다")
   private String password;
+
+  /** 로그인 유지 여부 (15일간 자동 로그인) */
+  private boolean rememberMe = false;
 }

--- a/admin-api/src/main/java/me/synology/hajubal/coins/admin/security/JwtTokenProvider.java
+++ b/admin-api/src/main/java/me/synology/hajubal/coins/admin/security/JwtTokenProvider.java
@@ -56,7 +56,21 @@ public class JwtTokenProvider {
    * @return JWT Refresh Token
    */
   public String createRefreshToken(String username) {
-    return createToken(username, jwtProperties.getRefreshTokenValidity(), "refresh");
+    return createRefreshToken(username, false);
+  }
+
+  /**
+   * Refresh Token 생성 (Remember Me 지원)
+   *
+   * @param username 사용자 이름
+   * @param rememberMe 로그인 유지 여부 (true: 15일, false: 7일)
+   * @return JWT Refresh Token
+   */
+  public String createRefreshToken(String username, boolean rememberMe) {
+    Long validity = rememberMe
+        ? jwtProperties.getRememberMeTokenValidity()
+        : jwtProperties.getRefreshTokenValidity();
+    return createToken(username, validity, "refresh");
   }
 
   /**

--- a/admin-api/src/main/resources/application.yml
+++ b/admin-api/src/main/resources/application.yml
@@ -38,6 +38,7 @@ jwt:
   secret: your-secret-key-change-this-in-production-at-least-256-bits-long
   access-token-validity: 900000  # 15분 (밀리초)
   refresh-token-validity: 604800000  # 7일 (밀리초)
+  remember-me-token-validity: 1296000000  # 15일 (밀리초)
 
 # CORS 설정
 cors:

--- a/admin-web/src/hooks/useAuth.ts
+++ b/admin-web/src/hooks/useAuth.ts
@@ -7,12 +7,12 @@ export const useAuth = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const login = async (loginId: string, password: string) => {
+  const login = async (loginId: string, password: string, rememberMe: boolean = false) => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const response = await authService.login({ loginId, password });
+      const response = await authService.login({ loginId, password, rememberMe });
       authService.saveUserInfo(response);
       navigate('/');
     } catch (err: unknown) {

--- a/admin-web/src/pages/Login.tsx
+++ b/admin-web/src/pages/Login.tsx
@@ -10,6 +10,7 @@ export default function Login() {
   const [loginId, setLoginId] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -17,7 +18,7 @@ export default function Login() {
     setError('');
 
     try {
-      await login(loginId, password);
+      await login(loginId, password, rememberMe);
     } catch (err) {
       setError(authError || 'Login failed. Please try again.');
     }
@@ -79,6 +80,22 @@ export default function Login() {
                     <i className={`bx ${showPassword ? 'bx-show' : 'bx-hide'} text-lg`}></i>
                   </button>
                 </div>
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  id="rememberMe"
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+                />
+                <Label
+                  htmlFor="rememberMe"
+                  className="text-sm font-normal cursor-pointer"
+                >
+                  Remember me for 15 days
+                </Label>
               </div>
 
               <Button type="submit" className="w-full" disabled={isLoading}>

--- a/admin-web/src/services/auth.ts
+++ b/admin-web/src/services/auth.ts
@@ -3,6 +3,7 @@ import axiosInstance from '@/lib/axios';
 export interface LoginRequest {
   loginId: string;
   password: string;
+  rememberMe?: boolean;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## Summary
로그인 화면에 "Remember Me" 체크박스를 추가하여 사용자가 15일간 자동 로그인을 유지할 수 있도록 구현했습니다.

## 주요 변경사항

### Backend
- `LoginRequest.java`: `rememberMe` 필드 추가 (기본값: false)
- `JwtProperties.java`: `rememberMeTokenValidity` 설정 필드 추가
- `JwtTokenProvider.java`: Remember Me 지원 토큰 생성 메서드 추가
  - `createRefreshToken(username, rememberMe)` 오버로드 메서드 구현
- `AuthController.java`: 로그인 시 rememberMe 값에 따른 토큰 발급 로직 적용
- `application.yml`: remember-me-token-validity 설정 추가 (15일 = 1,296,000,000ms)

### Frontend
- `Login.tsx`: "Remember me for 15 days" 체크박스 UI 추가
- `auth.ts`: `LoginRequest` 인터페이스에 `rememberMe` 옵셔널 필드 추가
- `useAuth.ts`: `login()` 함수에 `rememberMe` 파라미터 추가

## 동작 방식
- **Remember Me 체크 시**: Refresh Token 유효기간 15일
- **Remember Me 미체크 시**: Refresh Token 유효기간 7일 (기존 동작 유지)
- 브라우저 종료 후 재시작 시 localStorage의 토큰이 유효하면 자동 로그인

## 테스트 결과
✅ Remember Me 체크 시 15일 Refresh Token 발급 확인
✅ Remember Me 미체크 시 7일 Refresh Token 발급 확인 (기존 호환성 유지)
✅ 로그인/로그아웃 정상 동작 확인
✅ Backend 빌드 성공
✅ Frontend 빌드 성공

## 스크린샷
로그인 화면에 "Remember me for 15 days" 체크박스가 추가되었습니다.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)